### PR TITLE
Polymorphic definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ object of a specific type and let the container figure out the dependencies:
 user = User.new
 facebook_service = FacebookService.new
 container = Injectable::Container.new(user, facebook_service)
-user_service = container.get(UserService)
+user_service = container.get(:user_service)
 ```
 
 Since `User` and `FacebookService` take no arguments, we don't even need to
@@ -54,8 +54,8 @@ pass them into the container - it will automatically instantiate new ones:
 
 ```ruby
 container = Injectable::Container.new
-user = container.get(User)
-user_service = container.get(UserService)
+user = container.get(:user)
+user_service = container.get(:user_service)
 ```
 
 Injectable also supports depending on roles rather than concrete classes by
@@ -64,8 +64,8 @@ allowing the registration of classes whose instances perform that role:
 ```ruby
 container = Injectable::Container.new
 container.register(:facebook_service, DifferentFacebookService)
-user_service = container.get(UserService)
-# `user_service`'s facebook_service will be an implementation of
+user_service = container.get(:user_service)
+# `user_service`'s facebook_service will be an instance of
 # DifferentFacebookService
 ```
 

--- a/README.md
+++ b/README.md
@@ -58,8 +58,18 @@ user = container.get(User)
 user_service = container.get(UserService)
 ```
 
-Polymorphism is not supported since we don't have interfaces in Ruby. Setter
-injection is also not supported.
+Injectable also supports depending on roles rather than concrete classes by
+allowing the registration of classes whose instances perform that role:
+
+```ruby
+container = Injectable::Container.new
+container.register(:facebook_service, DifferentFacebookService)
+user_service = container.get(UserService)
+# `user_service`'s facebook_service will be an implementation of
+# DifferentFacebookService
+```
+
+Setter injection is not supported.
 
 How about the real world
 ------------------------

--- a/lib/injectable.rb
+++ b/lib/injectable.rb
@@ -3,6 +3,7 @@ require "active_support/inflector"
 require "injectable/container"
 require "injectable/macros"
 require "injectable/registry"
+require "injectable/role_not_registered"
 
 # Objects that include Injectable can have their dependencies satisfied by the
 # container, and removes some basic boilerplate code of creating basic

--- a/lib/injectable/container.rb
+++ b/lib/injectable/container.rb
@@ -11,9 +11,7 @@ module Injectable
     # @example Get an instance of an object for class UserService.
     #   container.get(UserService)
     #
-    # @param [ Class, Symbol ] role If a Class, the type of the object to
-    #                               return. If a Symbol, the role which the
-    #                               returned object should perform.
+    # @param [ Symbol ] role the role which the returned object should perform.
     #
     # @return [ Object ] The instantiated object.
     #
@@ -22,11 +20,7 @@ module Injectable
     #
     # @since 0.0.0
     def get(role)
-      klass = if role.is_a?(Symbol)
-                implementing_class_for(role)
-              else
-                role
-              end
+      klass = implementing_class_for(role)
       if instantiated_objects.has_key?(klass)
         instantiated_objects[klass]
       else
@@ -85,7 +79,12 @@ module Injectable
     end
 
     def implementing_class_for(role)
-      implementing_classes.fetch(role) { raise Injectable::RoleNotRegistered.new(role) }
+      klass = implementing_classes[role]
+      if klass.nil? && Object.const_defined?(role.to_s.classify)
+        klass = role.to_s.classify.constantize
+      end
+      raise Injectable::RoleNotRegistered.new(role) if klass.nil?
+      klass
     end
   end
 end

--- a/lib/injectable/registry.rb
+++ b/lib/injectable/registry.rb
@@ -19,7 +19,7 @@ module Injectable
     #
     # @since 0.0.0
     def add(klass, dependencies)
-      signatures[klass] = dependencies.map { |name| name.to_s.classify.constantize }
+      signatures[klass] = dependencies.map { |name| name }
     end
 
     # Get the constructor method signature for the provided class.

--- a/lib/injectable/role_not_registered.rb
+++ b/lib/injectable/role_not_registered.rb
@@ -1,0 +1,11 @@
+module Injectable
+  class RoleNotRegistered < StandardError
+    def initialize(role)
+      @role = role
+    end
+
+    def message
+      "No class registered to perform #{@role}"
+    end
+  end
+end

--- a/spec/injectable/container_spec.rb
+++ b/spec/injectable/container_spec.rb
@@ -40,7 +40,7 @@ describe Injectable::Container do
       end
 
       it "returns the cached instance" do
-        expect(container.get(UserService)).to eql(service)
+        expect(container.get(:user_service)).to eql(service)
       end
     end
 
@@ -51,11 +51,11 @@ describe Injectable::Container do
       end
 
       it "returns a new instance" do
-        expect(container.get(UserService)).to be_a(UserService)
+        expect(container.get(:user_service)).to be_a(UserService)
       end
 
       it "caches the instance" do
-        expect(container.get(UserService)).to eql(container.get(UserService))
+        expect(container.get(:user_service)).to eql(container.get(UserService))
       end
     end
 
@@ -66,12 +66,12 @@ describe Injectable::Container do
       end
 
       it "returns a new instance" do
-        expect(container.get(UserService)).to be_a(UserService)
+        expect(container.get(:user_service)).to be_a(UserService)
       end
 
       it "returns instances of the no arg objects" do
-        expect(container.get(User)).to be_a(User)
-        expect(container.get(UserFinder)).to be_a(UserFinder)
+        expect(container.get(:user)).to be_a(User)
+        expect(container.get(:user_finder)).to be_a(UserFinder)
       end
     end
 
@@ -87,6 +87,11 @@ describe Injectable::Container do
       it "returns an instance of the specified class for that role" do
         expect(container.get(:user_finder)).to be_an(AnotherUserFinder)
       end
+
+      it "continues to wire up dependent objects correctly" do
+        user_service = container.get(:user_service)
+        expect(user_service.user_finder).to be_an(AnotherUserFinder)
+      end
     end
 
     context "when asked for a role but no class registered" do
@@ -94,8 +99,23 @@ describe Injectable::Container do
         described_class.new
       end
 
-      it "raises Injectable::RoleNotRegistered" do
-        expect { container.get(:user_finder) }.to raise_error(Injectable::RoleNotRegistered)
+      it "returns the an instance of the class most likely to match the role" do
+        expect(container.get(:user_finder)).to be_a(UserFinder)
+      end
+
+      context "and there's no defined constant matching the role name" do
+        before do
+          Object.__send__(:remove_const, :UserFinder)
+        end
+
+        it "raises Injectable::RoleNotRegistered" do
+          expect { container.get(:user_finder) }.to raise_error(Injectable::RoleNotRegistered)
+        end
+
+        after do
+          #avoid triggering an error in the after(:all) block above
+          class UserFinder; end
+        end
       end
     end
   end

--- a/spec/injectable/container_spec.rb
+++ b/spec/injectable/container_spec.rb
@@ -11,12 +11,14 @@ describe Injectable::Container do
         include Injectable
         dependencies :user, :user_finder
       end
+      class AnotherUserFinder; end
     end
 
     after(:all) do
       Object.__send__(:remove_const, :User)
       Object.__send__(:remove_const, :UserFinder)
       Object.__send__(:remove_const, :UserService)
+      Object.__send__(:remove_const, :AnotherUserFinder)
     end
 
     let(:user) do
@@ -70,6 +72,30 @@ describe Injectable::Container do
       it "returns instances of the no arg objects" do
         expect(container.get(User)).to be_a(User)
         expect(container.get(UserFinder)).to be_a(UserFinder)
+      end
+    end
+
+    context "when a specified class is registered for a given role" do
+      let(:container) do
+        described_class.new
+      end
+
+      before do
+        container.register(:user_finder, AnotherUserFinder)
+      end
+
+      it "returns an instance of the specified class for that role" do
+        expect(container.get(:user_finder)).to be_an(AnotherUserFinder)
+      end
+    end
+
+    context "when asked for a role but no class registered" do
+      let(:container) do
+        described_class.new
+      end
+
+      it "raises Injectable::RoleNotRegistered" do
+        expect { container.get(:user_finder) }.to raise_error(Injectable::RoleNotRegistered)
       end
     end
   end

--- a/spec/injectable/macros_spec.rb
+++ b/spec/injectable/macros_spec.rb
@@ -40,7 +40,7 @@ describe Injectable::Macros do
       end
 
       it "adds the signature to the registry" do
-        expect(Injectable::Registry.signature(UserService)).to eq([ User ])
+        expect(Injectable::Registry.signature(UserService)).to eq([ :user ])
       end
     end
 
@@ -77,7 +77,7 @@ describe Injectable::Macros do
       it "adds the signature to the registry" do
         expect(
           Injectable::Registry.signature(UserService)
-        ).to eq([ User, UserFinder ])
+        ).to eq([ :user, :user_finder ])
       end
     end
   end

--- a/spec/injectable/registry_spec.rb
+++ b/spec/injectable/registry_spec.rb
@@ -18,8 +18,8 @@ describe Injectable::Registry do
       described_class.add(User, [ :user_finder ])
     end
 
-    it "constantizes the provided symbols" do
-      expect(described_class.signature(User)).to eq([ UserFinder ])
+    it "remembers the dependencies of the class" do
+      expect(described_class.signature(User)).to eq([ :user_finder ])
     end
   end
 end


### PR DESCRIPTION
This allows users to register specific classes as performing roles, rather than the class returned by name.to_s.classify.constantize, and hence the swapping in of different implementors of dependencies at run time. I've made README and documentation changes as appropriate. There's a major change to the user-facing API, in that Container#get now accepts the role's name as a `Symbol` (although I suppose a `String` would probably work, too - lolruby) rather than the specific class desired.
